### PR TITLE
AnyEvent->one_event replaced by $AnyEvent::MODEL . '::_poll'

### DIFF
--- a/lib/IO/Lambda/Loop/AnyEvent.pm
+++ b/lib/IO/Lambda/Loop/AnyEvent.pm
@@ -103,7 +103,11 @@ sub after
 
 sub yield
 {
-	AnyEvent-> one_event;
+        my $model = $AnyEvent::MODEL;
+        {
+            no strict 'refs';
+            ($model . '::_poll')->();
+        }
 }
 
 sub remove


### PR DESCRIPTION
Or so it seems.

From the AnyEvent changelog for version 6.01 Fri Aug 26 07:04:11 CEST 2011:

        - INCOMPATIBLE CHANGE: backend authors now should not implement
          one_event or loop, but instead the AnyEvent::CondVar::_wait and _poll
          methods.

Script to reproduce:

    #!/usr/bin/perl -w
    use strict;

    use AnyEvent;
    use IO::Lambda::Loop::AnyEvent; # explicitly select the event loop module
    use IO::Lambda qw(:lambda par);

    my $timer = IO::Lambda-> new;
    $timer-> watch_timer(1, sub {
        print "Timer expired\n";
    });
    $timer->wait;

    print "Wait done\n";

Without this commit, it dies:

    Can't locate object method "one_event" via package "AnyEvent" at /usr/share/perl5/IO/Lambda/Loop/AnyEvent.pm line 106.

With this commit:

    Timer expired
    Wait done